### PR TITLE
Nfe cleanup

### DIFF
--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -12,14 +12,10 @@ import collections
 # nfelib imports
 # xsd NFe
 from nfelib.v4_00 import leiauteNFe_sub as nfe_sub
-from nfelib.v4_00 import leiauteInutNFe
-from nfelib.v4_00 import consStatServ
+from nfelib.v4_00 import retInutNFe
 from nfelib.v4_00 import retConsStatServ
-from nfelib.v4_00 import consSitNFe
 from nfelib.v4_00 import retConsSitNFe
-from nfelib.v4_00 import enviNFe
 from nfelib.v4_00 import retEnviNFe
-from nfelib.v4_00 import consReciNFe
 from nfelib.v4_00 import retConsReciNFe
 
 # xsd Distrito Federal
@@ -27,18 +23,16 @@ from nfelib.v4_00 import distDFeInt
 from nfelib.v4_00 import retDistDFeInt
 
 # xsd Evento Generico
-from nfelib.v4_00 import leiauteEvento
 from nfelib.v4_00 import retEnvEvento
 
 # xsd Evento Cancelamento
-from nfelib.v4_00 import leiauteEventoCancNFe
+from nfelib.v4_00 import retEnvEventoCancNFe
 
 # xsd CCe
-from nfelib.v4_00 import leiauteCCe
+from nfelib.v4_00 import retEnvCCe
 
-# xsd Manifestação do destinatário - TODO limpar a geracao
-from nfelib.v4_00 import leiauteConfRecebtoManifestacao as confRecebto
-from nfelib.v4_00 import leiauteConfRecebto as confRecebto2
+# xsd Manifestação do destinatário - TODO checar se precisa de algum override
+from nfelib.v4_00 import retEnvConfRecebto
 
 from erpbrasil.edoc.edoc import DocumentoEletronico
 
@@ -758,7 +752,7 @@ class NFe(DocumentoEletronico):
         return edoc.infNFe.Id[:3], edoc.infNFe.Id[3:]
 
     def status_servico(self):
-        raiz = consStatServ.TConsStatServ(
+        raiz = retConsStatServ.TConsStatServ(
             versao=self.versao,
             tpAmb=self.ambiente,
             cUF=self.uf,
@@ -775,7 +769,7 @@ class NFe(DocumentoEletronico):
         )
 
     def consulta_documento(self, chave):
-        raiz = consSitNFe.TConsSitNFe(
+        raiz = retConsSitNFe.TConsSitNFe(
             versao=self.versao,
             tpAmb=self.ambiente,
             xServ='CONSULTAR',
@@ -803,7 +797,7 @@ class NFe(DocumentoEletronico):
         """
         xml_assinado = self.assina_raiz(edoc, edoc.infNFe.Id)
 
-        raiz = enviNFe.TEnviNFe(
+        raiz = retEnviNFe.TEnviNFe(
             versao=self.versao,
             idLote=datetime.datetime.now().strftime('%Y%m%d%H%M%S'),
             indSinc='0'
@@ -851,7 +845,7 @@ class NFe(DocumentoEletronico):
         if not numero:
             return
 
-        raiz = consReciNFe.TConsReciNFe(
+        raiz = retConsReciNFe.TConsReciNFe(
             versao=self.versao,
             tpAmb=self.ambiente,
             nRec=numero,
@@ -870,14 +864,14 @@ class NFe(DocumentoEletronico):
         if not numero_lote:
             numero_lote = self._gera_numero_lote()
 
-        raiz = leiauteEvento.TEnvEvento(versao="1.00", idLote=numero_lote)
+        raiz = retEnvEvento.TEnvEvento(versao="1.00", idLote=numero_lote)
         raiz.original_tagname_ = 'envEvento'
         xml_envio_string, xml_envio_etree = self._generateds_to_string_etree(
             raiz
         )
 
         for raiz_evento in lista_eventos:
-            evento = leiauteEventoCancNFe.TEvento(
+            evento = retEnvEventoCancNFe.TEvento(
                 versao="1.00", infEvento=raiz_evento,
             )
             evento.original_tagname_ = 'evento'
@@ -896,7 +890,7 @@ class NFe(DocumentoEletronico):
                           data_hora_evento=False):
         tipo_evento = '110111'
         sequencia = '1'
-        raiz = leiauteEventoCancNFe.infEventoType(
+        raiz = retEnvEventoCancNFe.infEventoType(
             Id='ID' + tipo_evento + chave + sequencia.zfill(2),
             cOrgao=self.uf,
             tpAmb=self.ambiente,
@@ -906,7 +900,7 @@ class NFe(DocumentoEletronico):
             tpEvento='110111',
             nSeqEvento='1',
             verEvento='1.00',
-            detEvento=leiauteEventoCancNFe.detEventoType(
+            detEvento=retEnvEventoCancNFe.detEventoType(
                 versao="1.00",
                 descEvento='Cancelamento',
                 nProt=protocolo_autorizacao,
@@ -919,7 +913,7 @@ class NFe(DocumentoEletronico):
     def carta_correcao(self, chave, sequencia, justificativa,
                        data_hora_evento=False):
         tipo_evento = '110110'
-        raiz = leiauteCCe.infEventoType(
+        raiz = retEnvCCe.infEventoType(
             Id='ID' + tipo_evento + chave + sequencia.zfill(2),
             cOrgao=self.uf,
             tpAmb=self.ambiente,
@@ -930,7 +924,7 @@ class NFe(DocumentoEletronico):
             tpEvento=tipo_evento,
             nSeqEvento=sequencia,
             verEvento='1.00',
-            detEvento=leiauteCCe.detEventoType(
+            detEvento=retEnvCCe.detEventoType(
                 versao="1.00",
                 descEvento='Carta de Correcao',
                 xCorrecao=justificativa,
@@ -1055,7 +1049,7 @@ class NFe(DocumentoEletronico):
             numero_lote = self._gera_numero_lote()
 
         eventos = []
-        raiz = leiauteEvento.TEnvEvento(
+        raiz = retEnvEvento.TEnvEvento(
             versao="1.00",
             idLote=numero_lote,
             evento=eventos
@@ -1063,7 +1057,7 @@ class NFe(DocumentoEletronico):
         raiz.original_tagname_ = 'envEvento'
 
         for raiz_evento in lista_eventos:
-            evento = confRecebto.TEvento(
+            evento = retEnvConfRecebto.TEvento(
                 versao="1.00", infEvento=raiz_evento,
             )
             evento.original_tagname_ = 'evento'
@@ -1073,7 +1067,7 @@ class NFe(DocumentoEletronico):
 
             # Converte o xml_assinado para um objeto pelo
             # parser do esquema leiauteConfRecebto
-            xml_object = confRecebto2.parseString(
+            xml_object = retEnvConfRecebto.parseString(
                 bytearray(xml_assinado, 'utf8'))
 
             # Adiciona o xml_object na lista de eventos. Desse modo a lista
@@ -1112,7 +1106,7 @@ class NFe(DocumentoEletronico):
         """
 
         nSeqEvento = '1'
-        raiz = confRecebto.infEventoType(
+        raiz = retEnvConfRecebto.infEventoType(
             Id='ID{}{}{}'.format(tpEvento, chave, nSeqEvento.zfill(2)),
             cOrgao=91,
             tpAmb=self.ambiente,
@@ -1123,7 +1117,7 @@ class NFe(DocumentoEletronico):
             tpEvento=tpEvento,
             nSeqEvento=nSeqEvento,
             verEvento='1.00',
-            detEvento=confRecebto.detEventoType(
+            detEvento=retEnvConfRecebto.detEventoType(
                 versao='1.00',
                 descEvento=descEvento,
                 xJust=xJust
@@ -1168,31 +1162,31 @@ class NFe(DocumentoEletronico):
         return self.nfe_recepcao_evento(
             chave,
             cnpj_cpf,
-            confRecebto.tpEventoType._2_10200,
-            confRecebto.descEventoType.CONFIRMACAODA_OPERACAO,
+            retEnvConfRecebto.tpEventoType._2_10200,
+            retEnvConfRecebto.descEventoType.CONFIRMACAODA_OPERACAO,
         )
 
     def ciencia_da_operacao(self, chave, cnpj_cpf):
         return self.nfe_recepcao_evento(
             chave,
             cnpj_cpf,
-            confRecebto.tpEventoType._2_10210,
-            confRecebto.descEventoType.CIENCIADA_OPERACAO,
+            retEnvConfRecebto.tpEventoType._2_10210,
+            retEnvConfRecebto.descEventoType.CIENCIADA_OPERACAO,
         )
 
     def desconhecimento_da_operacao(self, chave, cnpj_cpf):
         return self.nfe_recepcao_evento(
             chave,
             cnpj_cpf,
-            confRecebto.tpEventoType._2_10220,
-            confRecebto.descEventoType.DESCONHECIMENTODA_OPERACAO,
+            retEnvConfRecebto.tpEventoType._2_10220,
+            retEnvConfRecebto.descEventoType.DESCONHECIMENTODA_OPERACAO,
         )
 
     def operacao_nao_realizada(self, chave, cnpj_cpf):
         return self.nfe_recepcao_evento(
             chave,
             cnpj_cpf,
-            confRecebto.tpEventoType._2_10240,
-            confRecebto.descEventoType.OPERACAONAO_REALIZADA,
+            retEnvConfRecebto.tpEventoType._2_10240,
+            retEnvConfRecebto.descEventoType.OPERACAONAO_REALIZADA,
             xJust=''.zfill(15)
         )

--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -9,29 +9,39 @@ import time
 from lxml import etree
 import collections
 
-from nfelib.v4_00 import leiauteNFe
+# nfelib imports
+# xsd NFe
 from nfelib.v4_00 import leiauteNFe_sub as nfe_sub
+from nfelib.v4_00 import leiauteInutNFe
 from nfelib.v4_00 import consStatServ
 from nfelib.v4_00 import retConsStatServ
-from nfelib.v4_00 import retDistDFeInt
 from nfelib.v4_00 import consSitNFe
 from nfelib.v4_00 import retConsSitNFe
 from nfelib.v4_00 import enviNFe
 from nfelib.v4_00 import retEnviNFe
 from nfelib.v4_00 import consReciNFe
 from nfelib.v4_00 import retConsReciNFe
-from nfelib.v4_00 import leiauteEvento
-from nfelib.v4_00 import leiauteEventoCancNFe
-from nfelib.v4_00 import leiauteCCe
-from nfelib.v4_00 import retEnvEvento
-from nfelib.v4_00 import leiauteInutNFe
-from erpbrasil.edoc.edoc import DocumentoEletronico
 
+# xsd Distrito Federal
 from nfelib.v4_00 import distDFeInt
+from nfelib.v4_00 import retDistDFeInt
 
-# Manifestação do destinatário
+# xsd Evento Generico
+from nfelib.v4_00 import leiauteEvento
+from nfelib.v4_00 import retEnvEvento
+
+# xsd Evento Cancelamento
+from nfelib.v4_00 import leiauteEventoCancNFe
+
+# xsd CCe
+from nfelib.v4_00 import leiauteCCe
+
+# xsd Manifestação do destinatário - TODO limpar a geracao
 from nfelib.v4_00 import leiauteConfRecebtoManifestacao as confRecebto
 from nfelib.v4_00 import leiauteConfRecebto as confRecebto2
+
+from erpbrasil.edoc.edoc import DocumentoEletronico
+
 
 try:
     from StringIO import StringIO


### PR DESCRIPTION
Isso eh relacionado as mudancas da nfelib aqui: https://github.com/akretion/nfelib
( historico das mudancas nas fontes aqui https://github.com/akretion/nfelib/commits/master ).

postando aqui de novo a explicacao que eu tinha postado no Telegram e Hangout sobre essa limpeza da nfelib:

> entao, eu atualizei o nfelib da forma que eu acho correcto para manter e com um minimo de testes e com todos os esquemas usados hoje no erpbrasil.edocs https://github.com/akretion/nfelib
a coisa que eu considero fundamental para essas libs que usam o generateDS, eh que seja atualizado a cada commit/add de esquema esse tipo de receita do bolo de como refaz de novo do 0:
https://github.com/akretion/nfelib#gerir-a-lib-novamente--processo-de-release
isso eh fundamental se atualizar um esquema ou o generateDS, para poder atualizar sem criar regressoes com alguma gambiarra que nao foi documentada
um outro ponto fondamental eh separar a receita do bolo, testes e extencoes da parte da parte do codigo gerido
entao o codigo gerido, que fica navigavel para ler o codigo ou instalar com pip install do github ou pro release, fica na branch padrao do codigo gerido, no caso:
master_gen_v4_00
MAS
se algum precisar revisar uma contribuicao ou uma alteracao (imagina vc atualiza a prod depois de 6 meses o que sera que mudou?), ai as coisas ficam muito claro na branch master QUE NAO TEM O CODIGO GERIDO:
https://github.com/akretion/nfelib/commits/master
ai vc ve cada commit e pode olhar o diff fica perfeitamente legivel
outro ponto fondamental: ficar  DRY e leve
considerando os xsd do Distrito Federal e MDe, a lib de vcs tem todo isso:
https://github.com/akretion/nfelib/tree/master_gen_v4_00/nfelib/v4_00

> a minha tem TODAS classes usadas pelo erpbrasil.edocs e so tem 30% dos arquivos https://github.com/akretion/nfelib/tree/master_gen_v4_00/nfelib/v4_00
no caso do Mde talvez precisaria replicar um gambiarra que fizeram, mas teria que ver. Com o generateDS atualizado pode ser que varias gambiarras nao sejam mais necessarias
mas a ideia e nao atrasar os merge de l10n_br_nfe e GINFES na OCA por conta da ultimas coisas de mde
vamos fazer o merge do grosso das coisas primeiro e depois as melhorias
entao para ser menor, o ponto eh que qdo vc tem o xsd envNfe.xsd e retEnvNFe.xsd, esse segundo xsd inclue tudo que vc usa no erpbrasil.edocs ja
se vc pegar os arquivos py dos 2 vc dobra 95% do codigo de forma inutil
se vc depoiis quer rodar o Odoo em instancia de 512 Mb de RAM, se vc multiplicar o tamanho das libs fiscais assim pelo numero de libs usadas e pelo numero de workers aquil tem a sua importancia
com essas libs verbosa se vc bota muito arquivos de bobeira vc rapidamente dobra a quantidade de codigo que ta rodando comparando com o codigo do Odoo
entao meu ponto seria vcs da KMEE limparem a nfselib um pouco dessa forma
realmente eu nao quero ser chato, tudo bem se nao tem um historico igual da nfelib
tudo bem se tem 5x menos teste
tudo bem se tem gambiarras em vez de subclasses na GINFES
MAS no minimo teria que ter a receita do bolo repetitivel na branch master e que seja diferente da branch gerida, um teste minimo de importacao das classes que usa
ser gerido com generateDS atualizado e nao de 2 anos atras
senao eh falacia que vc pode dar suporte nisso como vc daria num modulo OCA qualquer
vou escrever um RFC sobre isso
mas ai seria isso e botar um Travis no erpbrasil.edoc
ai a KMEE fazer essa limpeza de casa das dependencias dos PRs dela.