### PR TITLE
[ADD] Duque de Caxias na lista de cidades ISSnet

### DIFF
--- a/src/erpbrasil/edoc/provedores/cidades.py
+++ b/src/erpbrasil/edoc/provedores/cidades.py
@@ -20,6 +20,7 @@ cidades = {
     5002704: Dsf,  # Campo Grande - MS
     3550308: Paulistana,  # São Paulo - SP
     3543402: Issnet,    # Ribeirão Preto - SP
+    3301702: Issnet,  # Duque de Caxias - RJ
 }
 
 


### PR DESCRIPTION
Adiciona o código da cidade de Duque de Caxias na lista de cidades cobertas pelo ISSnet