### PR TITLE
Correção das URLs dos WS da NFe de MG

### DIFF
--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -463,24 +463,24 @@ UFMS = {
 UFMG = {
     AMBIENTE_PRODUCAO: {
         'servidor': 'nfe.fazenda.mg.gov.br',
-        WS_NFE_INUTILIZACAO: 'nfe2/services/NFeInutilizacao4?wsdl',
-        WS_NFE_CONSULTA: 'nfe2/services/NFeConsultaProtocolo4?wsdl',
-        WS_NFE_SITUACAO: 'nfe2/services/NFeStatusServico4?wsdl',
-        WS_NFE_RECEPCAO_EVENTO: 'nfe2/services/NFeRecepcaoEvento4?wsdl',
-        WS_NFE_AUTORIZACAO: 'nfe2/services/NFeAutorizacao4?wsdl',
-        WS_NFE_RET_AUTORIZACAO: 'nfe2/services/NFeRetAutorizacao4?wsdl',
-        WS_NFE_CADASTRO: 'nfe2/services/cadconsultacadastro2?wsdl',
+        WS_NFE_INUTILIZACAO: 'nfe2/services/NFeInutilizacao4',
+        WS_NFE_CONSULTA: 'nfe2/services/NFeConsultaProtocolo4',
+        WS_NFE_SITUACAO: 'nfe2/services/NFeStatusServico4',
+        WS_NFE_RECEPCAO_EVENTO: 'nfe2/services/NFeRecepcaoEvento4',
+        WS_NFE_AUTORIZACAO: 'nfe2/services/NFeAutorizacao4',
+        WS_NFE_RET_AUTORIZACAO: 'nfe2/services/NFeRetAutorizacao4',
+        WS_NFE_CADASTRO: 'nfe2/services/CadConsultaCadastro4',
 
     },
     AMBIENTE_HOMOLOGACAO: {
         'servidor': 'hnfe.fazenda.mg.gov.br',
-        WS_NFE_INUTILIZACAO: 'nfe2/services/NFeInutilizacao4?wsdl',
-        WS_NFE_CONSULTA: 'nfe2/services/NFeConsultaProtocolo4?wsdl',
-        WS_NFE_SITUACAO: 'nfe2/services/NFeStatusServico4?wsdl',
-        WS_NFE_RECEPCAO_EVENTO: 'nfe2/services/NFeRecepcaoEvento4?wsdl',
-        WS_NFE_AUTORIZACAO: 'nfe2/services/NFeAutorizacao4?wsdl',
-        WS_NFE_RET_AUTORIZACAO: 'nfe2/services/NFeRetAutorizacao4?wsdl',
-        WS_NFE_CADASTRO: 'nfe2/services/cadconsultacadastro2?wsdl',
+        WS_NFE_INUTILIZACAO: 'nfe2/services/NFeInutilizacao4',
+        WS_NFE_CONSULTA: 'nfe2/services/NFeConsultaProtocolo4',
+        WS_NFE_SITUACAO: 'nfe2/services/NFeStatusServico4',
+        WS_NFE_RECEPCAO_EVENTO: 'nfe2/services/NFeRecepcaoEvento4',
+        WS_NFE_AUTORIZACAO: 'nfe2/services/NFeAutorizacao4',
+        WS_NFE_RET_AUTORIZACAO: 'nfe2/services/NFeRetAutorizacao4',
+        WS_NFE_CADASTRO: 'nfe2/services/CadConsultaCadastro4',
     }
 }
 


### PR DESCRIPTION
Correção das URLs dos webservices da NFe para o estado de Minas Gerais de acordo com:

Ambiente de Produção:
https://www.nfe.fazenda.gov.br/portal/webServices.aspx?tipoConteudo=OUC/YVNWZfo=#MG

Ambiente de Homologação:
https://hom.nfe.fazenda.gov.br/portal/webServices.aspx#MG