### PR TITLE
[FIX] Tratamento do XML de resposta

### DIFF
--- a/src/erpbrasil/edoc/resposta.py
+++ b/src/erpbrasil/edoc/resposta.py
@@ -23,7 +23,18 @@ def analisar_retorno_raw(operacao, raiz, xml, retorno, classe):
                       retorno.text.replace('\n', ''))
     if match:
         xml_resposta = match.group(1)
-        resultado = etree.tostring(etree.fromstring(xml_resposta)[0])
+        xml_etree = etree.fromstring(xml_resposta)
+        resultado = xml_etree[0]
+
+        nome_classe = classe.__name__.split(".")[-1]
+        xml_classe_tags = list(filter(
+            lambda children: nome_classe in children.tag,
+            xml_etree.findall(".//")
+        ))
+        if xml_classe_tags:
+            resultado = xml_classe_tags[0]
+
+        resultado = etree.tostring(resultado)
         classe.Validate_simpletypes_ = False
         resposta = classe.parseString(resultado, silence=True)
         return RetornoSoap(operacao, raiz, xml, retorno, resposta)


### PR DESCRIPTION
Foi necessário alterar a forma de tratamento do XML de resposta, devido ao fato de alguns serviços da sefaz retornarem o XML  com mais de uma tag, como é o caso do `retDistDFeInt`: 

![Captura de tela de 2023-07-04 15-22-57](https://github.com/erpbrasil/erpbrasil.edoc/assets/50644973/fbc7d0ce-fb84-4b2b-b098-48af86af7d9a)

Nesse caso o tratamento era feito na primeira tag encontrada, `nfeDistDFeInteresseResult` ao invés da tag correta `retDistDFeInt`, fazendo com que a classe responsável pelo tratamento não encontre os dados para processar.

Para resolver, busquei por tags com o nome igual ao nome da classe responsável pelo tratamento, e caso não encontre nenhuma classe com esse nome, somente então utiliza a primeira tag encontrada.