### PR TITLE
[IMP] Alterando o tempo médio da NFSe

### DIFF
--- a/src/erpbrasil/edoc/nfse.py
+++ b/src/erpbrasil/edoc/nfse.py
@@ -25,7 +25,7 @@ ServicoNFSe = collections.namedtuple(
 class NFSe(DocumentoEletronico):
     _consulta_servico_ao_enviar = False
     _maximo_tentativas_consulta_recibo = 10
-    _tempo_medio = 1
+    _tempo_medio = 1.5
     _header = False
     _namespace = False
 


### PR DESCRIPTION
Ontem a consulta do documento estava insuportavel no GINFES e o impacto é que o documento fiscal é gerado na prefeitura mas por demora no retorno da consulta do recibo acaba perdendo esta informação e no Odoo por exemplo ao tentar enviar novamente o documento como não tem nenhum protocolo o retorno é que o documento já foi gerado. @mileo @ygcarvalh o q acham de aumentar o tempo médio ? faz sentido ?