### PR TITLE
[FIX] NFCe documents processing

### DIFF
--- a/src/erpbrasil/edoc/nfce.py
+++ b/src/erpbrasil/edoc/nfce.py
@@ -5,7 +5,6 @@ import datetime
 import hashlib
 import xml.etree.ElementTree as ET
 import binascii
-import time
 
 from lxml import etree
 
@@ -251,7 +250,6 @@ NAMESPACES = {
 
 class NFCe(NFe):
     _edoc_situacao_arquivo_recebido_com_sucesso = '104'
-    _tempo_medio = 1
 
     def __init__(self, transmissao, uf, versao="4.00", ambiente="2", mod="65",
                  qrcode_versao="2", csc_token=None, csc_code=None):
@@ -335,7 +333,7 @@ class NFCe(NFe):
         )
 
     def _aguarda_tempo_medio(self, proc_envio):
-        time.sleep(self._tempo_medio)
+        pass
 
     def consulta_recibo(self, proc_envio):
         # Since NFCe is synchronous it is not necessary to consult the receipt,


### PR DESCRIPTION
O processamento de documentos NFCe estava sendo interrompido antes de finalizar completamente, devido ao atributo `_edoc_situacao_arquivo_recebido_com_sucesso` ser diferente entre NFe e NFCe.

Isso estava ocasionando a falta de atribuição do campo `processo_xml,` atributo na função `monta_processo`, e consequentemente ficando sem o XML para visualização no Odoo.

Como o NFCe é enviado de forma síncrona, não é necessário fazer a consulta do recibo após o envio do documento, então a função de consulta de recibo foi sobrescrita para que em documentos NFCe seja retornado o mesmo resultado do envio.