### PR TITLE
fix bad code; remove linebreak (cStat 588)

### DIFF
--- a/src/erpbrasil/edoc/edoc.py
+++ b/src/erpbrasil/edoc/edoc.py
@@ -224,7 +224,6 @@ class DocumentoEletronico(ABC):
         xml_assinado = Assinatura(self._transmissao.certificado).assina_xml2(
             xml_etree, id, getchildren
         )
-        return xml_assinado
         return xml_assinado.replace('\n', '').replace('\r', '')
 
     def _verifica_servico_em_operacao(self, proc_servico):


### PR DESCRIPTION
Esse return sobrando em cima tava um porcaria de codigo... Alem disso realmente agora é preciso tirar esses \n e \t na assinatura senão pega erros cStat 588 https://atendimento.tecnospeed.com.br/hc/pt-br/articles/360015725113-Rejei%C3%A7%C3%A3o-588-N%C3%A3o-%C3%A9-permitida-a-presen%C3%A7a-de-caracteres-de-edi%C3%A7%C3%A3o-no-in%C3%ADcio-fim-da-mensagem-ou-entre-as-tags-da-mensagem em alguns estados. Aconteceu num cliente no servidor de NFe do RS e isso resolveu...