### PR TITLE
Melhorias para NF-e

### DIFF
--- a/src/erpbrasil/edoc/nfce.py
+++ b/src/erpbrasil/edoc/nfce.py
@@ -258,9 +258,9 @@ class NFCe(NFe):
         qrcode_versao="2",
         csc_token=None,
         csc_code=None,
+        envio_sincrono=True,
     ):
-        super().__init__(transmissao, uf, versao, ambiente)
-        self.mod = str(mod)
+        super().__init__(transmissao, uf, versao, ambiente, mod, envio_sincrono)
         self.qrcode_versao = str(qrcode_versao)
         self.csc_token = str(csc_token)
         self.csc_code = str(csc_code)
@@ -333,7 +333,7 @@ class NFCe(NFe):
         raiz = retEnviNFe.TEnviNFe(
             versao=self.versao,
             idLote=datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-            indSinc="1",
+            indSinc="1" if self.envio_sincrono else "0",
         )
         raiz.original_tagname_ = "enviNFe"
         xml_envio_string, xml_envio_etree = self._generateds_to_string_etree(raiz)

--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -718,8 +718,11 @@ class NFe(DocumentoEletronico):
     _namespace = "http://www.portalfiscal.inf.br/nfe"
     _edoc_situacao_arquivo_recebido_com_sucesso = "103"
     _edoc_situacao_servico_em_operacao = "107"
-    _consulta_servico_ao_enviar = True
-    _consulta_documento_antes_de_enviar = True
+
+    # Desativado por padrão para evitar 'consumo indevido'
+    _consulta_servico_ao_enviar = False
+    _consulta_documento_antes_de_enviar = False
+
     _maximo_tentativas_consulta_recibo = 5
 
     def __init__(self, transmissao, uf, versao="4.00", ambiente="2", mod="55"):

--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -1037,6 +1037,20 @@ class NFe(DocumentoEletronico):
                 proc_recibo.protocolo = protocolo
             return True
 
+    def monta_nfe_proc(self, nfe, prot_nfe):
+        """
+        Constrói e retorna o XML do processo da NF-e,
+        incorporando a NF-e com o seu protocolo de autorização.
+        """
+        nfe_proc = etree.Element(
+            f"{{{self._namespace}}}nfeProc",
+            versao=self.versao,
+            nsmap={None: self._namespace},
+        )
+        nfe_proc.append(nfe)
+        nfe_proc.append(prot_nfe)
+        return etree.tostring(nfe_proc)
+
     def consultar_cadastro(self, uf, cnpj=None, cpf=None, ie=None):
         if not cnpj and not cpf and not ie:
             return

--- a/tests/test_erpbrasil_edoc_nfe.py
+++ b/tests/test_erpbrasil_edoc_nfe.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+
+from erpbrasil.edoc.nfe import NFe
+from lxml import etree
+
+
+class NFeTests(TestCase):
+    def setUp(self):
+        self.nfe = NFe(False, "35", versao="4.00", ambiente="1")
+        nfe_xml_str = """
+        <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+            <infNFe Id="NFe12345678901234567890123456789012345678901234" versao="4.00">
+                <ide>
+                    <cUF>35</cUF>
+                    <cNF>1234567</cNF>
+                    <natOp>Venda de mercadoria</natOp>
+                    <!-- Outros campos da tag ide -->
+                </ide>
+                <emit>
+                    <CNPJ>12345678000195</CNPJ>
+                    <xNome>Empresa Exemplo</xNome>
+                    <!-- Outros campos da tag emit -->
+                </emit>
+                <!-- Outras tags como det, total, transp, etc. -->
+            </infNFe>
+        </NFe>
+        """
+        prot_nfe_xml_str = """
+        <protNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00">
+            <infProt>
+                <tpAmb>1</tpAmb>
+                <verAplic>SP_NFE_PL_008i2</verAplic>
+                <chNFe>12345678901234567890123456789012345678901234</chNFe>
+                <dhRecbto>2024-01-16T14:00:00-03:00</dhRecbto>
+                <nProt>13579024681112</nProt>
+                <digVal>abcd1234abcd1234abcd1234abcd1234abcd1234=</digVal>
+                <cStat>100</cStat>
+                <xMotivo>Autorizado o uso da NF-e</xMotivo>
+            </infProt>
+        </protNFe>
+        """
+        self.nfe_element = etree.fromstring(nfe_xml_str)
+        self.prot_nfe_element = etree.fromstring(prot_nfe_xml_str)
+
+    def test_monta_nfe_proc(self):
+        nfe_proc_bytes = self.nfe.monta_nfe_proc(
+            self.nfe_element, self.prot_nfe_element
+        )
+        root = etree.fromstring(nfe_proc_bytes)
+        self.assertIsInstance(nfe_proc_bytes, bytes)
+        self.assertEqual(root.tag, "{http://www.portalfiscal.inf.br/nfe}nfeProc")
+        children = list(root)
+        self.assertEqual(len(children), 2)
+        child_tags = [child.tag for child in children]
+        self.assertIn("{http://www.portalfiscal.inf.br/nfe}NFe", child_tags)
+        self.assertIn("{http://www.portalfiscal.inf.br/nfe}protNFe", child_tags)


### PR DESCRIPTION
Essa PR tem como proposta adicionar 3 melhorias para as **NF-e**

**1) Desativa por padrão a "consulta do status do serviço" e a "consulta da situação da nota" antes enviar.**
commit: 510bcd02018c853adf3959b3228eef9b85829eb3
- Essas consultas são desnecessaria e podem levar a um "Consumo Indevido" e ser penalizado pela sefaz com bloqueio.
- O proprio manual da NF-e explica que não é correto ficar verificando assim a cada envio, apenas depois de uma falha no envio, o usuário deve usar o serviço de consultar o status para poder confirmar se o serviço realmente está fora do ar.
- Diminui o tempo de resposta ao enviar a nota.
- Quanto ao ficar consultado o status da nota também penso que é um exagero, pois sabemos que 99,99% dos casos a nota não vai tá enviada, se por acaso o usuário receber um aviso de duplicidade ao tentar enviar, ai sim, pode consultar a situação da nota.

**2) Possibilidade de poder escolher a forma de transmissão sincrona.**
commit: 1dc1c05ed13081878817efa11bd11d45dcd86795
- Não são todos os estados que aceitam o envio sincrono, exemplo: SP, GO, BA. (aceitam apenas para NFC-e)
- a vantagem do modo sincrono é que o retorno do processamento da nota é bem mais rapido, não é preciso ficar aguardando para consultar o recibo.

**3) Adiciona uma função auxiliar para montar o arquivo final da NF-e.**
- é a tag nfeProc, essa tag inclui a nfe enviada mais o protocolo de autorização recebido da sefaz.
- Para o emitente a sefaz nunca retorna o xml da nfe completo, apenas o protocolo de autorização.
- A sefaz espera que o sistema emissor tenha guardado bem o xml da nota enviada :) 
commit a4407c5f3d318b8adf59b86128936a0163a04928




- [x] Depende da PR da refotoração do CI e testes: #71 