### PR TITLE
[FIX] Problema na emissão da NFC-e

### DIFF
--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -1027,7 +1027,9 @@ class NFe(DocumentoEletronico):
         )
 
     def monta_processo(self, edoc, proc_envio, proc_recibo=None):
-        nfe = proc_envio.envio_raiz.find("{" + self._namespace + "}NFe")
+        nfe = proc_envio.envio_raiz.find(
+            "{" + self._namespace + "}NFe"
+        )  # Se proc_envio for 'None', debugar o método 'analisar_retorno_raw'
         if proc_recibo:
             protocolos = proc_recibo.resposta.protNFe
         else:

--- a/src/erpbrasil/edoc/resposta.py
+++ b/src/erpbrasil/edoc/resposta.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 - TODAY Luis Felipe Mileo - KMEE INFORMATICA LTDA
 # License MIT
 
+import logging
 import re
 
 from lxml import etree
@@ -37,6 +38,8 @@ def analisar_retorno_raw(operacao, raiz, xml, retorno, classe):
         classe.Validate_simpletypes_ = False
         resposta = classe.parseString(resultado, silence=True)
         return RetornoSoap(operacao, raiz, xml, retorno, resposta)
+    else:
+        logging.warning("'match' em 'analisar_retorno_raw' é None")
 
 
 def analisar_retorno(operacao, raiz, xml, retorno, classe):

--- a/src/erpbrasil/edoc/resposta.py
+++ b/src/erpbrasil/edoc/resposta.py
@@ -17,7 +17,8 @@ class RetornoSoap:
 
 def analisar_retorno_raw(operacao, raiz, xml, retorno, classe):
     retorno.raise_for_status()
-    match = re.search("<soap:Body>(.*?)</soap:Body>", retorno.text.replace("\n", ""))
+    pattern = r"<[a-zA-Z0-9:]Body.?>(.*?)</[a-zA-Z0-9:]*Body>"
+    match = re.search(pattern, retorno.text.replace("\n", ""))
     if match:
         xml_resposta = match.group(1)
         xml_etree = etree.fromstring(xml_resposta)

--- a/src/erpbrasil/edoc/resposta.py
+++ b/src/erpbrasil/edoc/resposta.py
@@ -6,6 +6,10 @@ import re
 
 from lxml import etree
 
+combined_pattern = re.compile(
+    r"<soap:Body>(.*?)</soap:Body>|<[a-zA-Z0-9:]*Body[^>]*>(.*?)</[a-zA-Z0-9:]*Body>"
+)
+
 
 class RetornoSoap:
     def __init__(self, webservice, raiz, xml, retorno, resposta):
@@ -18,10 +22,9 @@ class RetornoSoap:
 
 def analisar_retorno_raw(operacao, raiz, xml, retorno, classe):
     retorno.raise_for_status()
-    pattern = r"<[a-zA-Z0-9:]Body.?>(.*?)</[a-zA-Z0-9:]*Body>"
-    match = re.search(pattern, retorno.text.replace("\n", ""))
+    match = re.search(combined_pattern, retorno.text.replace("\n", ""))
     if match:
-        xml_resposta = match.group(1)
+        xml_resposta = match.group(1) or match.group(2)
         xml_etree = etree.fromstring(xml_resposta)
         resultado = xml_etree[0]
 


### PR DESCRIPTION
A emissão de NFC-e estava com um problema:

O método analisar_retorno_raw possui uma variável 'match' que recebe o valor de uma busca no xml através de regex, porém, o 'soap' do regex não existe no xml, e sim 'env'