### PR TITLE
[FIX] nfe.py: workaround to handle operation name issue for the state…

### DIFF
--- a/src/erpbrasil/edoc/nfe.py
+++ b/src/erpbrasil/edoc/nfe.py
@@ -867,10 +867,14 @@ class NFe(DocumentoEletronico):
             xml_assinado = self.assina_raiz(evento, evento.infEvento.Id)
             xml_envio_etree.append(etree.fromstring(xml_assinado))
 
+        operacao_recepcao_evento = "nfeRecepcaoEvento"
+        if self.uf in [29, 41]:
+            operacao_recepcao_evento = "nfeRecepcaoEventoNF"
+
         return self._post(
             xml_envio_etree,
             self._get_ws_endpoint(WS_NFE_RECEPCAO_EVENTO),
-            "nfeRecepcaoEvento",
+            operacao_recepcao_evento,
             retEnvEvento,
         )
 


### PR DESCRIPTION
… of Bahia

Rebase e *cherry-pick* de [erpbrasil.edoc#50](https://github.com/erpbrasil/erpbrasil.edoc/pull/50).

As modificações no regex foram tratadas em:  
- [kmee/nfelib#1](https://github.com/kmee/nfelib/pull/1)  
- [akretion/nfelib#116](https://github.com/akretion/nfelib/pull/116)  

⚠ **Observação:** A duplicidade ocorre porque `edoc#latest` não é compatível com `nfelib#latest`. Resolver isso exigiria um esforço adicional, e no momento a prioridade é corrigir este problema. Pretendo tratar essa duplicidade futuramente.
