### PR TITLE
[FIX] Correção para não editar o edoc depois de assinado

### DIFF
--- a/src/erpbrasil/edoc/edoc.py
+++ b/src/erpbrasil/edoc/edoc.py
@@ -218,7 +218,7 @@ class DocumentoEletronico(ABC):
         xml_assinado = Assinatura(self._transmissao.certificado).assina_xml2(
             xml_etree, id, getchildren
         )
-        return xml_assinado.replace("\n", "").replace("\r", "")
+        return xml_assinado
 
     def _verifica_servico_em_operacao(self, proc_servico):
         return True


### PR DESCRIPTION
Durante a transmissão da NFe eu tive o erro 297 - Assinatura diferente do calculado, para evitar esse erro eu removi essa linha que edita o XML assinado porque qualquer edição deve ser feita antes da assinatura, após assinado não deve ser editado para evitar erros na assinatura.