### PR TITLE
[FIX] Reassinatura: descartar Signature antiga + injetar xmlns:ds defensivo

### DIFF
--- a/src/erpbrasil/edoc/edoc.py
+++ b/src/erpbrasil/edoc/edoc.py
@@ -214,6 +214,14 @@ class DocumentoEletronico(ABC):
         return datetime.strftime(datetime.now(), "%Y-%m-%d")
 
     def assina_raiz(self, raiz, id, getchildren=False):
+        # Garante que uma Signature pré-existente (ex.: re-envio de NF-e
+        # reconstruída a partir do XML já assinado) não seja serializada pelo
+        # generateDS, que escreve <ds:Signature> sem declarar xmlns:ds e
+        # quebra o etree.fromstring em _generateds_to_string_etree.
+        # Como vamos reassinar a raiz, descartar a Signature anterior é o
+        # comportamento correto.
+        if hasattr(raiz, "Signature") and raiz.Signature is not None:
+            raiz.Signature = None
         xml_string, xml_etree = self._generateds_to_string_etree(raiz)
         xml_assinado = Assinatura(self._transmissao.certificado).assina_xml2(
             xml_etree, id, getchildren

--- a/src/erpbrasil/edoc/edoc.py
+++ b/src/erpbrasil/edoc/edoc.py
@@ -61,6 +61,20 @@ class DocumentoEletronico(ABC):
             )
         contents = output.getvalue()
         output.close()
+        # Reforço defensivo: as legacy generateDS bindings
+        # (nfelib_legacy/v4_00/retEnviNFe.py:2218 e análogos) hardcodam
+        # `namespaceprefix_='ds:'` e `namespacedef_=''` ao exportar uma
+        # Signature pré-existente, gerando `<ds:Signature>` sem declarar
+        # `xmlns:ds`. Isso quebra o etree.fromstring abaixo. Detectar e
+        # injetar a declaração ausente para qualquer caller que não tenha
+        # zerado a Signature antes (ex.: assina_raiz já zera, mas outros
+        # caminhos podem chegar aqui com generateDS já assinado).
+        if "<ds:Signature" in contents and "xmlns:ds=" not in contents:
+            contents = contents.replace(
+                "<ds:Signature",
+                '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"',
+                1,
+            )
         return contents, etree.fromstring(contents)
 
     def _post(self, raiz, url, operacao, classe):


### PR DESCRIPTION
## Sintoma

Em ambientes com `signxml 4.x` (testado com `4.4.0`) e `cryptography 47`, ao **enviar** uma NF-e cujo objeto generateDS (`TNFe`) carrega uma `Signature` pré-existente (cenário típico de re-envio, em que o `edoc` é reconstruído a partir do XML já assinado armazenado), a transmissão estoura:

```
File ".../erpbrasil/edoc/edoc.py", line 64, in _generateds_to_string_etree
    return contents, etree.fromstring(contents)
...
lxml.etree.XMLSyntaxError: Namespace prefix ds on Signature is not defined, line 1, column 432
```

## Causa-raiz

O bug **não está em `erpbrasil.assinatura`** nem na versão do `signxml` — está nas legacy generateDS bindings (`src/erpbrasil/nfelib_legacy/v4_00/retEnviNFe.py`, `retInutNFe.py`, `retEnvEvento.py`, etc.):

```python
# retEnviNFe.py:2218 (e demais arquivos análogos)
self.Signature.export(
    outfile, level,
    namespaceprefix_='ds:',
    namespacedef_='',           # ← não declara xmlns:ds
    name_='Signature',
    pretty_print=pretty_print,
)
```

Quando o `TNFe` (ou TInutNFe, TEvento, etc.) tem `Signature` populada, o export gera:

```xml
<NFe xmlns="..."><ds:Signature><ds:SignedInfo>...
```

`<ds:Signature>` sem `xmlns:ds="..."` declarado em escopo visível. O `etree.fromstring(contents)` em `edoc.py:64` rejeita.

## Reprodução mínima

```python
from io import StringIO
from lxml import etree
from erpbrasil.nfelib_legacy.v4_00 import retEnviNFe as bindings

sig_xml = """<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\">
  <SignedInfo>
    <CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\"/>
    <SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/>
    <Reference URI=\"#x\"><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/>
      <DigestValue>YWFh</DigestValue></Reference>
  </SignedInfo>
  <SignatureValue>YmJi</SignatureValue>
  <KeyInfo><X509Data><X509Certificate>Y2Nj</X509Certificate></X509Data></KeyInfo>
</Signature>"""
sig_obj = bindings.SignatureType.factory()
sig_obj.build(etree.fromstring(sig_xml))
nfe = bindings.TNFe(infNFe=None, infNFeSupl=None, Signature=sig_obj)
nfe.original_tagname_ = "NFe"

buf = StringIO()
nfe.export(buf, 0, pretty_print=False,
           namespacedef_='xmlns=\"http://www.portalfiscal.inf.br/nfe\"')
contents = buf.getvalue()
print('<ds:Signature' in contents, 'xmlns:ds=' in contents)
# True False
etree.fromstring(contents)
# lxml.etree.XMLSyntaxError: Namespace prefix ds on Signature is not defined
```

## Independência da versão da signxml

O bug **não depende de signxml**. Reproduz-se igual em `signxml 2.10.1` e `4.4.0` — validei byte-a-byte que `assina_xml2` produz output idêntico nas duas versões. Usuários que pinavam `signxml<3.1.0` provavelmente seguiam um fluxo Odoo que nunca disparava o re-export de generateDS com `Signature` populada — não porque a versão antiga "consertasse" alguma coisa.

## Fix em duas camadas

### Camada 1 (causa-raiz semântica) — `assina_raiz`

Descartar `Signature` antes de serializar e re-assinar. Vamos chamar `assina_xml2` na sequência (que adiciona uma `Signature` nova); manter a antiga geraria assinatura dupla.

```python
def assina_raiz(self, raiz, id, getchildren=False):
    if hasattr(raiz, "Signature") and raiz.Signature is not None:
        raiz.Signature = None
    xml_string, xml_etree = self._generateds_to_string_etree(raiz)
    ...
```

### Camada 2 (defensiva) — `_generateds_to_string_etree`

O reporter aplicou só a Camada 1 e o erro persistiu — sinal de que existe um caller de `_generateds_to_string_etree` fora de `assina_raiz` que também recebe generateDS com Signature populada (provavelmente OCA `l10n_br_nfe` ou fluxo que invoca `_post` diretamente com edoc reconstruído). Como as legacy bindings são autogeradas em dezenas de arquivos, regenerá-las ou patchar todas é alto risco. Detectar e corrigir o output quebrado em um único ponto é mais seguro:

```python
contents = output.getvalue()
output.close()
if "<ds:Signature" in contents and "xmlns:ds=" not in contents:
    contents = contents.replace(
        "<ds:Signature",
        '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"',
        1,
    )
return contents, etree.fromstring(contents)
```

## Alternativas consideradas

1. **Só camada 1** — não cobre callers que invocam `_generateds_to_string_etree` por outras rotas (validado em campo).
2. **Só camada 2** — funciona, mas mantém a anomalia de re-serializar uma Signature antiga em `assina_raiz` (assinatura dupla potencial em código a jusante).
3. **Regenerar/patchar todas as legacy bindings** corrigindo `namespacedef_=''`. Invasivo, dezenas de arquivos auto-gerados, alto risco de regressão.

A combinação Camada 1 + Camada 2 cobre os dois cenários: **Camada 1** evita o lixo entrar no pipeline quando estamos prestes a re-assinar; **Camada 2** salva qualquer caller que esqueça de limpar.

## Test plan

- [x] Reproduzir o `XMLSyntaxError` em ambiente com `signxml==4.4.0`, `cryptography==47.0.0`, `lxml==6.x`
- [x] Validar Camada 1: `assina_raiz` deixa de levantar `XMLSyntaxError` (e descarta Signature antiga)
- [x] Validar Camada 2: chamada direta a `_generateds_to_string_etree(nfe_com_Signature)` retorna XML válido com `<ds:Signature xmlns:ds="...">`
- [x] Validar via `git diff` que apenas `edoc.py` foi alterado (8 linhas em `assina_raiz` + 14 linhas em `_generateds_to_string_etree`)
- [ ] Maintainer rodar `tox` / `pytest tests/`
- [ ] Validar em ambiente do reporter (Odoo 16 + signxml 4.4 + cryptography 47) com NF-e real

## Não relacionado (descartado durante o diagnóstico)

A discussão inicial com o reporter apontou `signer.namespaces = {None: signxml.namespaces.ds}` em `erpbrasil.assinatura/assinatura.py:74` e o uso de cert A1 com `signature_hash_algorithm=sha256` como suspeitos. **Ambos foram descartados empiricamente**:

- Pipeline completo (`nfelib` xsdata → `assina_xml2`) com `signxml 4.4.0` + `cryptography 47.0.0` + cert criado com `hashes.SHA256()` produz XML assinado **byte-idêntico** ao gerado em `signxml 2.10.1` (mesmo `DigestValue`, mesmo `SignatureValue`).
- O atributo `signer.namespaces` foi removido em `signxml ≥ 3.x` — a atribuição na L74 é no-op silencioso, mas o `signxml` 4.x já produz o `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">` correto por default.
- O algoritmo de hash do "selo" da AC sobre o cert (SHA256) é metadado e não interfere na assinatura RSA-SHA1 do XML, exigida pela SEFAZ.

Nenhuma alteração em `erpbrasil.assinatura` é necessária para esse caso.